### PR TITLE
Centralise and update dependencies.

### DIFF
--- a/SampleApp-Source/.gitignore
+++ b/SampleApp-Source/.gitignore
@@ -1,0 +1,19 @@
+# Generated files
+bin/
+gen/
+out/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Macs
+.DS_Store
+
+# IDEA/Android Studio project files, because
+# the project can be imported from settings.gradle
+.idea
+*.iml
+
+# Gradle cache
+.gradle

--- a/SampleApp-Source/build.gradle
+++ b/SampleApp-Source/build.gradle
@@ -1,15 +1,29 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.versions = [
+            'compile_sdk'          : 28,
+            'min_sdk'              : 21,
+            'android_gradle_plugin': '3.3.1',
+            'kotlin'               : '1.3.21',
+            'play_services'        : '4.2.0',
+            'firebase'             : '17.4.0',
+            'appcompat'            : '28.0.0',
+            'design'               : '28.0.0',
+            'gridlayout'           : '28.0.0',
+            'constraint_layout'    : '1.1.3',
+            'junit'                : '4.12',
+            'liveperson'           : '3.6.0'
+    ]
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:3.2.1'
+        classpath "com.android.tools.build:gradle:${versions.android_gradle_plugin}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
+        classpath "com.google.gms:google-services:${versions.play_services}"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/SampleApp-Source/gradle/wrapper/gradle-wrapper.properties
+++ b/SampleApp-Source/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 16 14:35:46 IDT 2018
+#Tue Feb 26 14:51:05 AEDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/SampleApp-Source/sample_app/build.gradle
+++ b/SampleApp-Source/sample_app/build.gradle
@@ -2,14 +2,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+def versionMajor = 3
+def versionMinor = 6
+def versionPatch = 0
+
 android {
-    compileSdkVersion 26
+    compileSdkVersion versions.compile_sdk
     defaultConfig {
         applicationId "com.liveperson.sample.app"
-        minSdkVersion 19
-        targetSdkVersion 26
-        versionCode 360
-        versionName "3.6.0"
+        minSdkVersion versions.min_sdk
+        targetSdkVersion versions.compile_sdk
+        versionCode versionMajor * 100 + versionMinor * 10 * versionPatch
+        versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -25,15 +29,15 @@ android {
 }
 
 dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "com.google.firebase:firebase-messaging:11.0.2"
-    implementation "com.android.support:appcompat-v7:26.1.0"
-    implementation "com.android.support:design:26.1.0"
-    implementation "com.android.support:gridlayout-v7:26.1.0"
-    implementation "com.android.support.constraint:constraint-layout:1.0.2"
-    testImplementation "junit:junit:4.12"
+    implementation "com.google.firebase:firebase-messaging:${versions.firebase}"
+    implementation "com.android.support:appcompat-v7:${versions.appcompat}"
+    implementation "com.android.support:design:${versions.design}"
+    implementation "com.android.support:gridlayout-v7:${versions.gridlayout}"
+    implementation "com.android.support.constraint:constraint-layout:${versions.constraint_layout}"
+    testImplementation "junit:junit:${versions.junit}"
 
-    implementation 'com.liveperson.android:lp_messaging_sdk:3.6.0'
+    implementation "com.liveperson.android:lp_messaging_sdk:${versions.liveperson}"
 }
 
 apply plugin: 'com.google.gms.google-services'
+googleServices { disableVersionCheck = true } // TODO Remove this when LivePerson updates their dependency.


### PR DESCRIPTION
Once everything is managed in one place it'll make it easier to start the migration to AndroidX 😉.